### PR TITLE
[feat] 게시글 리스트 api, image resize 적용

### DIFF
--- a/postgresql/init_image.sql
+++ b/postgresql/init_image.sql
@@ -8,3 +8,6 @@ CREATE TABLE IMAGE
 
 INSERT INTO IMAGE (post_id, image_url) VALUES
   (1, 'https://cityhiker.s3.ap-northeast-2.amazonaws.com/1.webp');
+
+INSERT INTO IMAGE (post_id, image_url) VALUES
+  (2, 'https://wonyang-alpha-image.s3.us-east-2.amazonaws.com/IMG_1136.JPG');

--- a/src/logic/board.ts
+++ b/src/logic/board.ts
@@ -24,7 +24,7 @@ export const getPostList = async (
   const postList = await db_post.getPostForBoard(convertedType, page, campusId);
 
   const postListForClient: IPostBoardList[] = postList.map((post) => {
-    const imageUrl = getResizedImage(post.image_url) || defaultUrl;
+    const imageUrl = getResizedImage(post.image_url) ?? defaultUrl;
 
     return {
       id: post.id,

--- a/src/logic/board.ts
+++ b/src/logic/board.ts
@@ -1,6 +1,7 @@
 import { IPostBoardList } from '../interface/interface';
 import { TPOST_STATUS } from '../interface/types';
 import * as db_post from '../db/post';
+import { getResizedImage } from '../util';
 
 const converStatusName = (type: 'in_progress'): TPOST_STATUS | null => {
   switch (type) {
@@ -23,7 +24,7 @@ export const getPostList = async (
   const postList = await db_post.getPostForBoard(convertedType, page, campusId);
 
   const postListForClient: IPostBoardList[] = postList.map((post) => {
-    const imageUrl = post.image_url || defaultUrl;
+    const imageUrl = getResizedImage(post.image_url) || defaultUrl;
 
     return {
       id: post.id,

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,15 +1,15 @@
 import { JwtPayload, sign, SignOptions, verify } from 'jsonwebtoken';
 import { IJwtData } from '../interface/interface';
 
-const createToken = (data: IJwtData) => {
+const createToken = (data: IJwtData): string => {
   return sign(data, process.env.JWT_SECRET, { expiresIn: '1h' } as SignOptions);
 };
 
-const verifyToken = (token: string) => {
+const verifyToken = (token: string): JwtPayload => {
   return verify(token, process.env.JWT_SECRET) as JwtPayload;
 };
 
-const getResizedImage = (url: string) => {
+const getResizedImage = (url: string): null | string => {
   if (!url) return null;
 
   const urlList = url.split('/');

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -9,4 +9,21 @@ const verifyToken = (token: string) => {
   return verify(token, process.env.JWT_SECRET) as JwtPayload;
 };
 
-export { createToken, verifyToken };
+const getResizedImage = (url: string) => {
+  if (!url) return null;
+
+  const urlList = url.split('/');
+
+  if (urlList.length < 3) return null;
+
+  const imageName = urlList[urlList.length - 1];
+  const region = process.env.AWS_REGION;
+  const uploadBucket = process.env.UPLOAD_BUCKET;
+
+  if (!region) return null;
+  if (!uploadBucket) return null;
+
+  return `https://${uploadBucket}-resize.s3.${region}.amazonaws.com/resized-${imageName}`;
+};
+
+export { createToken, verifyToken, getResizedImage };


### PR DESCRIPTION
- 게시글 리스트를 가져오는 api에서 반환하는 image의 url을 resized된 이미지 url을 내려주도록 기능 추가

**resized 이미지를 내려주는 화면**
![image](https://user-images.githubusercontent.com/8137615/140753241-b34817fb-e6e7-42e2-a278-4f95c9372300.png)
